### PR TITLE
Potential i2c fix, cap piezo payload size, buffer overflow fixes

### DIFF
--- a/Core/Inc/piezo.h
+++ b/Core/Inc/piezo.h
@@ -10,7 +10,7 @@ void ascii_to_int (char * bufferIn, int * bufferOut);
 bool record_was_empty(char * bufferIn);
 void piezo_get_data(unsigned char *buf, unsigned long len, unsigned long data_offset);
 int piezo_get_data_length(void);
-void convert_to_8bit(uint8_t * buffer, uint16_t length);
+void convert_to_big_endian(uint8_t * buffer, uint16_t length);
 void clear_piezo_buffer(void);
 void RS485(uint8_t);
 

--- a/Core/Inc/piezo.h
+++ b/Core/Inc/piezo.h
@@ -8,7 +8,7 @@ void piezo_start_exp(void);
 bool piezo_checksum(int *piezoBufferRx);
 void ascii_to_int (char * bufferIn, int * bufferOut);
 bool record_was_empty(char * bufferIn);
-void piezo_get_data(unsigned char *buf, long data_offset);
+void piezo_get_data(unsigned char *buf, unsigned long len, unsigned long data_offset);
 int piezo_get_data_length(void);
 void convert_to_8bit(uint8_t * buffer, uint16_t length);
 void clear_piezo_buffer(void);

--- a/Core/Inc/start_test.h
+++ b/Core/Inc/start_test.h
@@ -2,7 +2,7 @@
 //void convert_8bit(uint8_t * buffer);
 void setDAC(uint32_t);
 void start_test(void);
-void sic_get_data(unsigned char *buf, long data_offset);
+void sic_get_data(unsigned char *buf, unsigned long len, unsigned long data_offset);
 void clear_sic_buffer (void);
 void sic_test_driver(void);
 void readADCvalues(uint8_t);

--- a/Core/Lib/msp/src/msp_handlers.c
+++ b/Core/Lib/msp/src/msp_handlers.c
@@ -51,11 +51,11 @@ void msp_expsend_data(unsigned char opcode, unsigned char *buf, unsigned long le
 {
   if (opcode == REQ_PIEZO)
   {
-    piezo_get_data(buf, offset);
+    piezo_get_data(buf, len, offset);
   }
   else if (opcode == REQ_SIC)
   {
-     sic_get_data(buf, offset);
+     sic_get_data(buf, len, offset);
   }
 }
 

--- a/Core/Src/piezo.c
+++ b/Core/Src/piezo.c
@@ -111,8 +111,9 @@ void piezo_stop_exp(void)
 
 /**
  * @brief retrieves the data collected data from the buffer
- * @prarm buffer to copy the data to
- * @param the data offset
+ * @param buffer to copy the data to
+ * @param the amount of data to copy
+ * @param the data offset from where to start copying
  */
 void piezo_get_data(unsigned char *buf, unsigned long len, unsigned long data_offset)
 {

--- a/Core/Src/start_test.c
+++ b/Core/Src/start_test.c
@@ -61,13 +61,11 @@ void clear_sic_buffer (void)
 }
 
 
-void sic_get_data(unsigned char *buf, long data_offset)
+void sic_get_data(unsigned char *buf, unsigned long len, unsigned long data_offset)
 {
-  uint16_t i =0;
-  while (i<BUFFERLENGTH)
+  for (unsigned long i = data_offset; i < BUFFERLENGTH && i - data_offset < len; i++)
   {
-    buf[i] = buffer[i];
-    i++;
+    buf[i - data_offset] = buffer[i];
   }
 }
 


### PR DESCRIPTION
@Bellmanz This code is untested, but should hopefully fix the I2C-MSP integration. It also adds an upper limit of 400 to the piezo legs payload size. I chose it somewhat arbitrarily as it was double the size of the 16 bit integer buffer, so it can be changed to whatever is appropriate. It also fixes a few other bugs I mentioned last friday and over mail.